### PR TITLE
Updated payment addressing bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -144,7 +144,7 @@ app.post("/paystack/webhook", async (req, res) => {
       user: data.metadata.userId,
       transactionId: transactionId,
       customerId: data.customer.customer_code,
-      address: data.metadata.address.address,
+      address: data.metadata.address,
       phone: data.metadata.phone,
       totalAmount: data.amount / 100,
       paymentMode: "Paystack",


### PR DESCRIPTION
This pull request includes a change to the `app.post("/paystack/webhook", async (req, res) => {` endpoint in the `app.js` file. The change modifies the way the address is accessed from the `data.metadata` object.

* [`app.js`](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL147-R147): Changed the `address` property to access `data.metadata.address` directly instead of `data.metadata.address.address`.