### PR TITLE
Order refund functionalities completed

### DIFF
--- a/app.js
+++ b/app.js
@@ -184,8 +184,8 @@ app.post("/paystack/webhook", async (req, res, next) => {
     }
     (order.status = "cancelled"),
       (order.refund = {
-        refundReference: data.refund_reference,
-        amount: data.amount,
+        refundReference: data.transaction_reference,
+        amount: data.amount / 100,
         status: data.status,
         processedAt: new Date(),
       });


### PR DESCRIPTION
This pull request includes a change to the `app.post("/paystack/webhook", async (req, res, next) => {` route in the `app.js` file. The change modifies the refund reference and amount handling within the webhook.

* [`app.js`](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL187-R188): Updated the `refundReference` to use `data.transaction_reference` instead of `data.refund_reference` and adjusted the `amount` to be divided by 100.